### PR TITLE
Remove punctuation when calculating features

### DIFF
--- a/run_gunicorn.sh
+++ b/run_gunicorn.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Initialize options for gunicorn
 OPTS=(
   --env FLASK_APP=wayback_discover_diff

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -18,6 +18,21 @@ abc
     features = {'123': 1, 'abc': 2, 'my': 1, 'test': 1, 'title': 1, 'space': 1}
     assert extract_html_features(html) == features
 
+    # handle html with repeated elements, and punctuation
+    html = """<html>
+<title>my title</title>
+<body>
+abc
+a.b.c.
+abc.
+test
+123
+abc
+</body>
+</html>"""
+    features = {'123': 1, 'abc': 4, 'my': 1, 'test': 1, 'title': 1}
+    assert extract_html_features(html) == features
+
     # handle plain text
     html = "just a string"
     features = {'just': 1, 'a': 1, 'string': 1}
@@ -37,7 +52,7 @@ abc
 <p>Thank you for closing the message box.</p>
 <a href="/subpage">test</a>
 </body></html>"""
-    features = {'box.': 1, 'closing': 1, 'for': 1, 'message': 1, 'test': 1,
+    features = {'box': 1, 'closing': 1, 'for': 1, 'message': 1, 'test': 1,
                 'thank': 1, 'the': 1, 'you': 1}
     assert extract_html_features(html) == features
 
@@ -49,7 +64,7 @@ abc
 
 </body>
 </html>"""
-    features = {'/\x94invalid\'': 1, 'invalid': 1, '今日は': 1}
+    features = {'\x94invalid': 1, 'invalid': 1, '今日は': 1}
     assert extract_html_features(html) == features
 
 

--- a/wayback_discover_diff/discover.py
+++ b/wayback_discover_diff/discover.py
@@ -1,6 +1,7 @@
 import json
 import concurrent.futures
 import logging
+import string
 from datetime import datetime
 import cProfile
 import struct
@@ -22,6 +23,7 @@ def extract_html_features(html):
     """Process HTML document and get key features as text. Steps:
     kill all script and style elements
     get lowercase text
+    remove all punctuation
     break into lines and remove leading and trailing space on each
     break multi-headlines into a line each
     drop blank lines
@@ -31,6 +33,8 @@ def extract_html_features(html):
     for script in soup(["script", "style"]):
         script.extract()
     text = soup.get_text().lower()
+    translator = str.maketrans('', '', string.punctuation)
+    text = text.translate(translator)
     lines = (line.strip() for line in text.splitlines())
     chunks = (phrase.strip() for line in lines for phrase in line.split("  "))
     text = '\n'.join(chunk for chunk in chunks if chunk)


### PR DESCRIPTION
In this PR I am changing the algorithm that calculates the features of the html code given to it so it will not take into account any punctuation. This means that, for example, "a.b.c" and "abc" will be counted as the same word "abc".

I also made the appropriate changes to the tests.